### PR TITLE
Add PackageSqlite3c sbt task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,3 +13,12 @@ scalacOptions in Test ++= Seq("-deprecation")
 testOptions in Test += Tests.Argument("-Djava.library.path=target/native")
 
 publishTo := Some(Resolver.file("file",  new File( "releases" )) )
+
+lazy val packageSqlite3C = taskKey[Unit]("Packages only Sqlite3C.java")
+
+packageSqlite3C := {
+  (compile in Compile).value
+  val cmd = Seq("jar", "-cf", s"${crossTarget.value}/sqlite3c-${version.value}.jar",
+    "-C", (classDirectory in Compile).value.toString, "org/srhea/scalaqlite/Sqlite3C.class")
+  if ((cmd ! streams.value.log) != 0) error("Couldn't package Sqlite3C")
+}


### PR DESCRIPTION
It is useful to have a jar that just contains the Sqlite3C class because
that is the only class that depends on the native libscalaqlite. This
matters if you are using scalaqlite in a webapp that has hot reloads.
Any class that loads a native library can only be loaded once per jvm.
To handle this some webapps, such as jetty, allow the user to set some
classes to be loaded with a specific classloader. Generally this
requires you to check in a jar in the webapp's lib directory.
Previously, because scalaqlite requires the scala standard library, the
user would have also had to check in the scala standard library into the
lib directory. With this change, they'll only have to check in the tiny
jar generated by this task.
