### PR TITLE
Add runtime selection of threading mode

### DIFF
--- a/src/main/java/Sqlite3C.java
+++ b/src/main/java/Sqlite3C.java
@@ -26,7 +26,12 @@ public class Sqlite3C {
     public static final int BLOB = 4;
     public static final int NULL = 5;
 
-    native static public int open(String path, long[] db);
+    // Flags to pass into open_v2
+    // Refer to [https://www.sqlite.org/c3ref/c_open_autoproxy.html]
+    public static final int MULTITHREAD = 0x00008002;
+    public static final int DEFAULT     = 0x00000002;
+
+    native static public int open_v2(String path, long[] db, int flags, String vfs);
     native static public int close(long db);
     native static public int enable_load_extension(long db, int onoff);
     native static public int prepare_v2(long db, String sql, long[] stmt);

--- a/src/main/native/Sqlite3C.cc
+++ b/src/main/native/Sqlite3C.cc
@@ -14,17 +14,19 @@
 #include <sqlite3.h>
 
 JNIEXPORT jint JNICALL
-Java_org_srhea_scalaqlite_Sqlite3C_open(JNIEnv *env, jclass cls, jstring jpath, jlongArray jdb)
+Java_org_srhea_scalaqlite_Sqlite3C_open_v2(JNIEnv *env, jclass cls, jstring jpath, jlongArray jdb, jint flags, jstring vfs)
 {
     jboolean iscopy;
     const char *cpath = env->GetStringUTFChars(jpath, &iscopy);
+    const char *cvfs = env->GetStringUTFChars(jvfs, &iscopy);
     sqlite3 *db;
-    jint r = sqlite3_open(cpath, &db);
+    jint r = sqlite3_open_v2(cpath, &db, flags, cvfs);
     if (r == SQLITE_OK) {
         jlong a[] = {(jlong) db};
         env->SetLongArrayRegion(jdb, 0, 1, a);
     }
     env->ReleaseStringUTFChars(jpath, cpath);
+    env->ReleaseStringUTFChars(jvfs, cvfs);
     return r;
 }
 

--- a/src/test/scala/SqliteDbSpec.scala
+++ b/src/test/scala/SqliteDbSpec.scala
@@ -10,6 +10,12 @@ import org.scalatest.Matchers
 class SqliteDbSpec extends FlatSpec with Matchers {
     val db = new SqliteDb(":memory:")
 
+    "database connections" should "work in multithreaded mode" in  {
+      val db2 = new SqliteDb(":memory:", SqlThreadingMode.Multithread)
+      db2.execute("CREATE TABLE foo (i INTEGER, f DOUBLE, t TEXT);")
+      db2.execute("INSERT INTO foo (i, f, t) VALUES (1, 2.0, 'foo');")
+    }
+
     "CREATE TABLE" should "not throw any exceptions" in {
         db.execute("CREATE TABLE foo (i INTEGER, f DOUBLE, t TEXT);")
     }


### PR DESCRIPTION
This change adds an option to the SqliteDb handler, which enables the
db connection to open in either serialized or multi-thread mode at
runtime.

Refer to [https://www.sqlite.org/threadsafe.html]
