### PR TITLE
Add ability to pass flags to "open" method.

### DIFF
--- a/src/main/java/Sqlite3C.java
+++ b/src/main/java/Sqlite3C.java
@@ -26,7 +26,19 @@ public class Sqlite3C {
     public static final int BLOB = 4;
     public static final int NULL = 5;
 
-    native static public int open(String path, long[] db);
+    // Flags to pass into open_v2
+    // Refer to [https://www.sqlite.org/c3ref/c_open_autoproxy.html]
+    public static final int SQLITE_OPEN_READONLY     = 0x00000001;  /* Ok for sqlite3_open_v2() */
+    public static final int SQLITE_OPEN_READWRITE    = 0x00000002;  /* Ok for sqlite3_open_v2() */
+    public static final int SQLITE_OPEN_CREATE       = 0x00000004;  /* Ok for sqlite3_open_v2() */
+    public static final int SQLITE_OPEN_URI          = 0x00000040;  /* Ok for sqlite3_open_v2() */
+    public static final int SQLITE_OPEN_MEMORY       = 0x00000080;  /* Ok for sqlite3_open_v2() */
+    public static final int SQLITE_OPEN_NOMUTEX      = 0x00008000;  /* Ok for sqlite3_open_v2() */
+    public static final int SQLITE_OPEN_FULLMUTEX    = 0x00010000;  /* Ok for sqlite3_open_v2() */
+    public static final int SQLITE_OPEN_SHAREDCACHE  = 0x00020000;  /* Ok for sqlite3_open_v2() */
+    public static final int SQLITE_OPEN_PRIVATECACHE = 0x00040000;  /* Ok for sqlite3_open_v2() */
+
+    native static public int open_v2(String path, long[] db, int flags, String vfs);
     native static public int close(long db);
     native static public int enable_load_extension(long db, int onoff);
     native static public int prepare_v2(long db, String sql, long[] stmt);

--- a/src/main/native/Sqlite3C.cc
+++ b/src/main/native/Sqlite3C.cc
@@ -14,17 +14,19 @@
 #include <sqlite3.h>
 
 JNIEXPORT jint JNICALL
-Java_org_srhea_scalaqlite_Sqlite3C_open(JNIEnv *env, jclass cls, jstring jpath, jlongArray jdb)
+Java_org_srhea_scalaqlite_Sqlite3C_open_1v2(JNIEnv *env, jclass cls, jstring jpath, jlongArray jdb, jint flags, jstring jvfs)
 {
     jboolean iscopy;
     const char *cpath = env->GetStringUTFChars(jpath, &iscopy);
+    const char *cvfs = jvfs == NULL ? NULL : env->GetStringUTFChars(jvfs, &iscopy);
     sqlite3 *db;
-    jint r = sqlite3_open(cpath, &db);
+    jint r = sqlite3_open_v2(cpath, &db, flags, cvfs);
     if (r == SQLITE_OK) {
         jlong a[] = {(jlong) db};
         env->SetLongArrayRegion(jdb, 0, 1, a);
     }
     env->ReleaseStringUTFChars(jpath, cpath);
+    env->ReleaseStringUTFChars(jvfs, cvfs);
     return r;
 }
 

--- a/src/main/scala/SqliteDb.scala
+++ b/src/main/scala/SqliteDb.scala
@@ -99,9 +99,14 @@ class SqliteResultIterator(db: SqliteDb, private val stmt: Long)
     }
 }
 
-class SqliteDb(path: String) {
+object SqliteDb {
+    import Sqlite3C._
+    final val BaseFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+}
+
+class SqliteDb(path: String, flags: Int = SqliteDb.BaseFlags) {
     private val db = Array(0L)
-    Sqlite3C.open(path, db) ensuring (_ == Sqlite3C.OK, errmsg)
+    Sqlite3C.open_v2(path, db, flags, null) ensuring (_ == Sqlite3C.OK, errmsg)
     def close() {
         assert(db(0) != 0, "already closed")
         Sqlite3C.close(db(0)) ensuring (_ == Sqlite3C.OK, errmsg)

--- a/src/test/scala/SqliteDbSpec.scala
+++ b/src/test/scala/SqliteDbSpec.scala
@@ -10,6 +10,13 @@ import org.scalatest.Matchers
 class SqliteDbSpec extends FlatSpec with Matchers {
     val db = new SqliteDb(":memory:")
 
+    "database connections" should "work in multithreaded mode" in  {
+      val db2 = new SqliteDb(":memory:", SqliteDb.BaseFlags | Sqlite3C.SQLITE_OPEN_NOMUTEX)
+      db2.execute("CREATE TABLE foo (i INTEGER, f DOUBLE, t TEXT);")
+      db2.execute("INSERT INTO foo (i, f, t) VALUES (1, 2.0, 'foo');")
+      db2.foreachRow("SELECT count(*) FROM foo;") (_ should equal (SqlLong(1) :: Nil))
+    }
+
     "CREATE TABLE" should "not throw any exceptions" in {
         db.execute("CREATE TABLE foo (i INTEGER, f DOUBLE, t TEXT);")
     }


### PR DESCRIPTION
We want to be able to open Sqlite in multithreaded mode. This requires using a different open method on the Sqlite library (open_v2), and adding the "NOMUTEX" flag.

Here I pass by default the flags that maintain the settings used by the original "open" method (OPEN_READWRITE | OPEN_CREATE).
